### PR TITLE
Added a bool-option for pre-mounting images on external playback.

### DIFF
--- a/MovingPictures/MovingPicturesSettings.cs
+++ b/MovingPictures/MovingPicturesSettings.cs
@@ -1723,6 +1723,24 @@ namespace MediaPortal.Plugins.MovingPictures {
         }
         private string _externalPlayerArguements;
 
+
+        [CornerstoneSetting(
+            Name = "External Player PreMounting",
+            Description = "A boolean which defines, if we should do pre-mount images for the external player or not (available states: 'True' is doing a pre-mount of images for the external player, 'False' no pre-mounting of images will be done)",
+            Groups = "|MediaPortal GUI|Bluray/HD-DVD Playback|",
+            Identifier = "playback_hd_premounting",
+            Default = true)]
+        public bool ExternalPlayerPreMounting
+        {
+            get { return _externalPlayerPreMounting; }
+            set
+            {
+                _externalPlayerPreMounting = value;
+                OnSettingChanged("playback_hd_premounting");
+            }
+        }
+        private bool _externalPlayerPreMounting;
+
         #endregion
 
         #region Sorting


### PR DESCRIPTION
MoviePlayer will check if it should "pre-mount" the images when using an external player.
If not, we just skip the mounting-process.

Reasons for such an Option:
PowerDVD15 (for example) can mount Images itself when passing the path to it.

Also:
PDVD (re-) starts ist own instance with another playback-mode - at this Point Media Portal is loosing PDVD, thinking that the Playback has been ended.
This results in an unmount of the Image and the actual Playback could not be started.
[See here](http://forum.team-mediaportal.com/threads/powerdvd-15-launcher-fix-3d-playback-with-daemon-tools.133586/)

Side-Effekt if not pre-mounting for PDVD:
The above behaviour don't exists, when we let PDVD mount the Images.
And even better: Users of PDVD, who aren't able to mount Images natively (Windows 8+) woan't Need a third Party mounting Software like DaemonTools for example.
